### PR TITLE
Add back button and draggable forms

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,16 @@
 /* ──────────  View Switching  ────────── */
 const mainPage    = document.getElementById('main-page');
 const builderPage = document.getElementById('builder-page');
+const backBtn     = document.getElementById('backBtn');
 
 document.getElementById('newBtn').onclick = () => {
   mainPage.hidden    = true;
   builderPage.hidden = false;
+};
+
+backBtn.onclick = () => {
+  builderPage.hidden = true;
+  mainPage.hidden    = false;
 };
 
 document.getElementById('loadBtn').onclick = () =>
@@ -45,6 +51,12 @@ dropZone.addEventListener('drop', ev => {
 
 /*  Helper: create a visual block in the assembly  */
 function addComponent(tool){
+  if(tool.shape){
+    const div = document.createElement('div');
+    div.className = `shape ${tool.shape}`;
+    dropZone.appendChild(div);
+    return;
+  }
   const div = document.createElement('div');
   div.className = 'bha-component';
   div.innerHTML = `
@@ -56,6 +68,6 @@ function addComponent(tool){
 
 /*  Helper: rebuild the assembly from imported JSON list  */
 function loadAssembly(arr){
-  dropZone.querySelectorAll('.bha-component').forEach(el => el.remove());
+  dropZone.querySelectorAll('.bha-component, .shape').forEach(el => el.remove());
   arr.forEach(addComponent);
 }

--- a/index.html
+++ b/index.html
@@ -23,26 +23,23 @@
 
   <!-- ────────────  BUILDER VIEW  ──────────── -->
   <section id="builder-page" class="view builder" hidden>
-    <!-- left: scrollable palette -->
-    <aside id="palette" class="sidebar">
-      <h2>Items</h2>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Drill Bit","length":0.5,"od":8.5}'>
-        Drill Bit<br><small>8.5"&nbsp;/&nbsp;0.5 ft</small>
-      </div>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Stabilizer","length":5,"od":6.375}'>
-        Stabilizer<br><small>Ø 6.375"&nbsp;/&nbsp;5 ft</small>
-      </div>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Jar","length":10,"od":3}'>
-        Jar<br><small>Ø 3"&nbsp;/&nbsp;10 ft</small>
-      </div>
-      <!-- …add more items here … -->
-    </aside>
+    <header class="builder-header">
+      <button id="backBtn" class="secondary">Back</button>
+    </header>
+    <div class="builder-body">
+      <!-- left: scrollable palette -->
+      <aside id="palette" class="sidebar">
+        <h2>Forms</h2>
+        <div class="tool-item" draggable="true" data-tool='{"shape":"rectangle"}'>Rectangle</div>
+        <div class="tool-item" draggable="true" data-tool='{"shape":"circle"}'>Circle</div>
+        <div class="tool-item" draggable="true" data-tool='{"shape":"triangle"}'>Triangle</div>
+      </aside>
 
-    <!-- right: drop zone -->
-    <main id="dropZone" class="dropzone" ondragover="event.preventDefault()">
-      <h2>Assy 1</h2>
-      <!-- dropped components appear below -->
-    </main>
+      <!-- right: drop zone -->
+      <main id="dropZone" class="dropzone" ondragover="event.preventDefault()">
+        <!-- dropped components appear below -->
+      </main>
+    </div>
   </section>
 
   <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -13,16 +13,23 @@ button:hover{filter:brightness(.95);}
 /*  ─── Layout Containers ───────────────────────────────── */
 .view{width:100vw;height:100vh;}
 .centered{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;}
-.builder{display:flex;}
+.builder{display:flex;flex-direction:column;}
 
 /*  ─── Sidebar (Item Palette) ──────────────────────────── */
-.sidebar{width:260px;background:#fff;border-right:1px solid #dcdce0;padding:1rem;overflow-y:auto;}
+.builder-header{padding:1rem;background:#fff;border-bottom:1px solid #dcdce0;}
+.builder-body{flex:1;display:flex;}
+.sidebar{flex:0 0 20%;min-width:160px;background:#fff;border-right:1px solid #dcdce0;padding:1rem;overflow-y:auto;}
 .tool-item{border:1px solid #dcdce0;border-radius:10px;padding:.6rem;margin-bottom:.6rem;background:#fefefe;cursor:grab;}
 .tool-item:active{cursor:grabbing;opacity:.8;}
 .tool-item small{color:#6e6e73;}
 
 /*  ─── Drop Zone (Assembly Stack) ──────────────────────── */
-.dropzone{flex:1;padding:1rem;overflow-y:auto;background:#e9f5ff;}
+.dropzone{flex:1;padding:1rem;overflow-y:auto;background:#fff;}
 .dropzone h2{margin-bottom:1rem;}
 .bha-component{border:2px solid #007aff;border-radius:8px;padding:.6rem;margin-bottom:.6rem;background:#fff;display:flex;justify-content:space-between;align-items:center;}
 .dim{color:#6e6e73;font-size:.9rem;}
+
+/*  ─── Simple Shape Previews ───────────────────────────── */
+.shape{width:100px;height:100px;border:2px solid #007aff;border-radius:4px;margin-bottom:.6rem;background:#e9f5ff;}
+.shape.circle{border-radius:50%;}
+.shape.triangle{width:0;height:0;border-left:50px solid transparent;border-right:50px solid transparent;border-bottom:100px solid #e9f5ff;border-radius:0;}


### PR DESCRIPTION
## Summary
- add a header with Back button in builder view
- make a left palette of draggable shapes
- allow shapes to be dropped in the white canvas
- adjust layout so the right side is white

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684745cb77ec8326a8d8290fc434b604