### PR TITLE
Implement BHA creation and history

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Fishing BHA Tool</title>
 
   <!--  Apple-inspired minimalist styling -->
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
 
@@ -14,8 +14,9 @@
   <section id="main-page" class="view centered">
     <h1>Fishing BHA Tool</h1>
 
-    <button id="loadBtn" class="primary">Load BHA</button>
-    <button id="newBtn"  class="secondary">New BHA</button>
+    <button id="newBtn" class="primary">New BHA</button>
+    <button id="historyBtn" class="secondary">Load BHA from browser history</button>
+    <button id="loadBtn" class="secondary">Load BHA from local files</button>
 
     <!-- hidden file picker -->
     <input type="file" id="fileInput" accept="application/json" hidden />


### PR DESCRIPTION
## Summary
- rename stylesheet link and add three main menu buttons
- implement BHA creation prompt and local storage
- allow loading BHA from browser history or local file
- store assemblies in localStorage for up to a month
- back up new BHA to a JSON file

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a98cdeb208326ab98ed6b1d623f84