### PR TITLE
Improve BHA creation workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,21 @@
     <input type="file" id="fileInput" accept="application/json" hidden />
   </section>
 
+  <!-- ────────────  BHA MENU  ──────────── -->
+  <section id="assembly-page" class="view centered" hidden>
+    <h1 id="bhaTitle">BHA</h1>
+    <div id="assemblyList" class="list"></div>
+    <button id="addAssyBtn" class="primary">Add Assembly</button>
+    <button id="backMainBtn" class="secondary back-btn">Back</button>
+  </section>
+
+  <!-- ────────────  LOAD MENU  ──────────── -->
+  <section id="load-page" class="view centered" hidden>
+    <h1>Select BHA</h1>
+    <div id="loadList" class="list"></div>
+    <button id="loadBackBtn" class="secondary back-btn">Back</button>
+  </section>
+
   <!-- ────────────  BUILDER VIEW  ──────────── -->
   <section id="builder-page" class="view builder" hidden>
     <!-- left: scrollable palette -->
@@ -41,8 +56,9 @@
 
     <!-- right: drop zone -->
     <main id="dropZone" class="dropzone" ondragover="event.preventDefault()">
-      <h2>Assy 1</h2>
+      <h2 id="assyTitle">Assy 1</h2>
       <!-- dropped components appear below -->
+      <button id="backAssyBtn" class="secondary back-btn">Back to Assemblies</button>
     </main>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -14,6 +14,10 @@ button:hover{filter:brightness(.95);}
 .view{width:100vw;height:100vh;}
 .centered{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;}
 .builder{display:flex;}
+.list{width:260px;text-align:left;margin-bottom:1rem;}
+.list button{margin:0.3rem 0;}
+.list div{display:flex;justify-content:space-between;}
+.back-btn{margin-top:1rem;}
 
 /*  ─── Sidebar (Item Palette) ──────────────────────────── */
 .sidebar{width:260px;background:#fff;border-right:1px solid #dcdce0;padding:1rem;overflow-y:auto;}


### PR DESCRIPTION
## Summary
- add dedicated assembly menu and load menu
- support managing multiple assemblies per BHA
- show list of saved BHAs when loading from history

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685a9b44805083269f2d74b9b419fe8b