### PR TITLE
Add canvas-based builder

### DIFF
--- a/assembly.html
+++ b/assembly.html
@@ -10,7 +10,7 @@
   <section class="view centered">
     <h1 id="bhaTitle">BHA</h1>
     <div id="assemblyList" class="list"></div>
-    <button id="addAssyBtn" class="primary">Add Assembly</button>
+    <button id="addAssyBtn" class="primary">New Assembly</button>
     <button id="backMainBtn" class="secondary back-btn">Back</button>
   </section>
   <script src="app.js"></script>

--- a/builder.html
+++ b/builder.html
@@ -3,25 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BHA Builder</title>
+  <title>Assembly Canvas</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="builder">
   <section class="view builder">
     <aside id="palette" class="sidebar">
-      <h2>Items</h2>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Drill Bit","length":0.5,"od":8.5}'>
-        Drill Bit<br><small>8.5"&nbsp;/&nbsp;0.5 ft</small>
-      </div>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Stabilizer","length":5,"od":6.375}'>
-        Stabilizer<br><small>Ø 6.375"&nbsp;/&nbsp;5 ft</small>
-      </div>
-      <div class="tool-item" draggable="true" data-tool='{"name":"Jar","length":10,"od":3}'>
-        Jar<br><small>Ø 3"&nbsp;/&nbsp;10 ft</small>
-      </div>
+      <h2>Public Components</h2>
+      <div id="publicList"></div>
+      <h2>Private Components</h2>
+      <input type="file" id="privateInput" accept="application/json" multiple />
+      <div id="privateList"></div>
     </aside>
-    <main id="dropZone" class="dropzone" ondragover="event.preventDefault()">
-      <h2 id="assyTitle">Assy 1</h2>
+    <main id="dropZone" class="dropzone">
+      <h2 id="assyTitle">Assembly Canvas</h2>
+      <canvas id="bhaCanvas" width="794" height="1123"></canvas>
       <button id="backAssyBtn" class="secondary back-btn">Back to Assemblies</button>
     </main>
   </section>

--- a/public_components.json
+++ b/public_components.json
@@ -1,0 +1,76 @@
+{
+  "components": [
+    {
+      "name": "Component 1",
+      "parts": [
+        {
+          "x": 1314.5,
+          "y": 20,
+          "width": 576,
+          "height": 755.9055118110235,
+          "color": "#369660",
+          "topConnector": "BOX",
+          "bottomConnector": "none",
+          "special": false,
+          "specialForms": [],
+          "symVertices": [
+            {"y": 0, "dx": 0},
+            {"y": 755.9055118110235, "dx": 0}
+          ]
+        },
+        {
+          "x": 1362.5,
+          "y": 775.9055118110234,
+          "width": 480,
+          "height": 120,
+          "color": "#2a794c",
+          "topConnector": "none",
+          "bottomConnector": "none",
+          "special": false,
+          "specialForms": [],
+          "symVertices": [
+            {"y": 0, "dx": 48},
+            {"y": 120, "dx": 0}
+          ]
+        },
+        {
+          "x": 1362.5,
+          "y": 895.9055118110234,
+          "width": 480,
+          "height": 377.95275590551176,
+          "color": "#369660",
+          "topConnector": "none",
+          "bottomConnector": "PIN",
+          "special": false,
+          "specialForms": [],
+          "symVertices": [
+            {"y": 0, "dx": 0},
+            {"y": 377.95275590551176, "dx": 0}
+          ]
+        }
+      ],
+      "drawnShapes": []
+    },
+    {
+      "name": "Component 2",
+      "parts": [
+        {
+          "x": 1314.5,
+          "y": 20,
+          "width": 576,
+          "height": 944.8818897637794,
+          "color": "#cccccc",
+          "topConnector": "BOX",
+          "bottomConnector": "PIN",
+          "special": false,
+          "specialForms": [],
+          "symVertices": [
+            {"y": 0, "dx": 0},
+            {"y": 944.8818897637794, "dx": 0}
+          ]
+        }
+      ],
+      "drawnShapes": []
+    }
+  ]
+}

--- a/style.css
+++ b/style.css
@@ -33,3 +33,6 @@ button:hover{filter:brightness(.95);}
 .dropzone h2{margin-bottom:1rem;}
 .bha-component{border:2px solid #007aff;border-radius:8px;padding:.6rem;margin-bottom:.6rem;background:#fff;display:flex;justify-content:space-between;align-items:center;}
 .dim{color:#6e6e73;font-size:.9rem;}
+
+/*  ─── Canvas ─────────────────────────────────────────── */
+#bhaCanvas{background:#fff;border:1px solid #dcdce0;margin-bottom:1rem;}


### PR DESCRIPTION
## Summary
- rename 'Add Assembly' to 'New Assembly'
- implement canvas-based builder page that loads components from JSON files
- allow importing private component sets
- persist placed components when navigating back
- fix back button on assembly page

## Testing
- `node -e "require('./app.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685aa6b179808326a59371ff629ba296