### PR TITLE
Fix assembly back to skip builder

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,7 +183,9 @@ if (bhaCanvas) {
     currentBha.assemblies[currentAssemblyIdx] = placed;
     saveCurrentBha();
     storeSession();
-    location.href = 'assembly.html';
+    // Replace the builder page in history so returning from assemblies
+    // never navigates back here
+    location.replace('assembly.html');
   };
 }
 


### PR DESCRIPTION
## Summary
- ensure returning from the builder page doesn't leave it in history

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ad006b2108326906a3fde835c2551