### PR TITLE
Update builder with scalable A4 canvas and title editing

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -9,6 +9,7 @@
 <body data-page="builder">
   <section class="view builder">
     <aside id="palette" class="sidebar">
+      <input id="assyTitle" class="assy-input" type="text" />
       <h2>Public Components</h2>
       <div id="publicList"></div>
       <h2>Private Components</h2>
@@ -16,7 +17,6 @@
       <div id="privateList"></div>
     </aside>
     <main id="dropZone" class="dropzone">
-      <h2 id="assyTitle">Assembly Canvas</h2>
       <canvas id="bhaCanvas" width="794" height="1123"></canvas>
       <button id="backAssyBtn" class="secondary back-btn">Back to Assemblies</button>
     </main>

--- a/style.css
+++ b/style.css
@@ -30,8 +30,9 @@ button:hover{filter:brightness(.95);}
 .tool-item small{color:#6e6e73;}
 
 /*  ─── Drop Zone (Assembly Stack) ──────────────────────── */
-.dropzone{flex:1;padding:1rem;overflow-y:auto;background:#e9f5ff;}
-.dropzone h2{margin-bottom:1rem;}
+.dropzone{flex:1;height:100%;padding:1rem;background:#e9f5ff;display:flex;flex-direction:column;align-items:center;overflow:auto;}
+
+.assy-input{width:100%;margin-bottom:1rem;padding:.4rem;font-size:1.1rem;}
 .bha-component{border:2px solid #007aff;border-radius:8px;padding:.6rem;margin-bottom:.6rem;background:#fff;display:flex;justify-content:space-between;align-items:center;}
 .dim{color:#6e6e73;font-size:.9rem;}
 
@@ -41,4 +42,4 @@ button:hover{filter:brightness(.95);}
 .load-row button{margin:0;}
 
 /*  ─── Canvas ─────────────────────────────────────────── */
-#bhaCanvas{background:#fff;border:1px solid #dcdce0;margin-bottom:1rem;}
+#bhaCanvas{background:#fff;border:1px solid #dcdce0;margin-bottom:1rem;height:100%;aspect-ratio:210/297;width:auto;max-height:calc(100vh - 6rem);}


### PR DESCRIPTION
## Summary
- allow the builder to edit the assembly name
- scale the canvas to fill the page and add an A4 engineering frame
- adjust styles for the builder view

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685ae1c5132c8326b73c335d5d2214be