### PR TITLE
Improve builder layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -226,19 +226,22 @@ if (bhaCanvas) {
     ctx.strokeRect(margin, margin, bhaCanvas.width - margin * 2, bhaCanvas.height - margin * 2);
     const tbW = 180;
     const tbH = 80;
-    const big = 40;
+    const smallRow = tbH / 4;
     const x = bhaCanvas.width - margin - tbW;
     const y = bhaCanvas.height - margin - tbH;
     ctx.strokeRect(x, y, tbW, tbH);
     ctx.beginPath();
-    ctx.moveTo(x, y + big);
-    ctx.lineTo(x + tbW, y + big);
-    const rowH = (tbH - big) / 3;
-    ctx.moveTo(x, y + big + rowH);
-    ctx.lineTo(x + tbW, y + big + rowH);
-    ctx.moveTo(x, y + big + rowH * 2);
-    ctx.lineTo(x + tbW, y + big + rowH * 2);
+    ctx.moveTo(x, y + smallRow);
+    ctx.lineTo(x + tbW, y + smallRow);
+    ctx.moveTo(x + tbW / 2, y);
+    ctx.lineTo(x + tbW / 2, y + smallRow);
     ctx.stroke();
+
+    ctx.font = '12px sans-serif';
+    ctx.fillStyle = '#000';
+    ctx.fillText('Title:', x + 4, y + 14);
+    ctx.fillText(assyObj.name, x + tbW / 2 + 4, y + 14);
+    ctx.fillText('Comment:', x + 4, y + smallRow + 14);
   }
 
   function redraw() {

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@ button:hover{filter:brightness(.95);}
 .list button{margin:0.3rem 0;}
 .list div{display:flex;justify-content:space-between;}
 .back-btn{margin-top:1rem;}
+.view.builder .back-btn{position:absolute;bottom:1rem;left:1rem;margin-top:0;}
 
 /*  ensure older browsers respect the hidden attribute  */
 [hidden]{display:none!important;}
@@ -30,7 +31,7 @@ button:hover{filter:brightness(.95);}
 .tool-item small{color:#6e6e73;}
 
 /*  ─── Drop Zone (Assembly Stack) ──────────────────────── */
-.dropzone{flex:1;height:100%;padding:1rem;background:#e9f5ff;display:flex;flex-direction:column;align-items:center;overflow:auto;}
+.dropzone{flex:1;height:100%;padding:1rem;background:#e9f5ff;display:flex;flex-direction:column;align-items:center;overflow:auto;position:relative;}
 
 .assy-input{width:100%;margin-bottom:1rem;padding:.4rem;font-size:1.1rem;}
 .bha-component{border:2px solid #007aff;border-radius:8px;padding:.6rem;margin-bottom:.6rem;background:#fff;display:flex;justify-content:space-between;align-items:center;}


### PR DESCRIPTION
## Summary
- tweak builder page layout
- draw two-row, two-column title block with comment area
- show assembly name on the title block

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685ae5b9fd3c8326ac06a91f8c76ff01