### PR TITLE
Improve assembly title block

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,6 +165,7 @@ if (bhaCanvas) {
   nameInput.value = assyObj.name;
   nameInput.addEventListener('input', () => {
     assyObj.name = nameInput.value.trim() || 'Assembly ' + (currentAssemblyIdx + 1);
+    redraw();
   });
 
   fetch('public_components.json')
@@ -224,23 +225,24 @@ if (bhaCanvas) {
     ctx.lineWidth = 2;
     ctx.strokeRect(0, 0, bhaCanvas.width, bhaCanvas.height);
     ctx.strokeRect(margin, margin, bhaCanvas.width - margin * 2, bhaCanvas.height - margin * 2);
-    const tbW = 180;
+    const tbW = 270; // 50% larger title block
     const tbH = 80;
     const smallRow = tbH / 4;
+    const titleCol = 50; // narrow column just wide enough for label
     const x = bhaCanvas.width - margin - tbW;
     const y = bhaCanvas.height - margin - tbH;
     ctx.strokeRect(x, y, tbW, tbH);
     ctx.beginPath();
     ctx.moveTo(x, y + smallRow);
     ctx.lineTo(x + tbW, y + smallRow);
-    ctx.moveTo(x + tbW / 2, y);
-    ctx.lineTo(x + tbW / 2, y + smallRow);
+    ctx.moveTo(x + titleCol, y);
+    ctx.lineTo(x + titleCol, y + smallRow);
     ctx.stroke();
 
     ctx.font = '12px sans-serif';
     ctx.fillStyle = '#000';
     ctx.fillText('Title:', x + 4, y + 14);
-    ctx.fillText(assyObj.name, x + tbW / 2 + 4, y + 14);
+    ctx.fillText(assyObj.name, x + titleCol + 4, y + 14);
     ctx.fillText('Comment:', x + 4, y + smallRow + 14);
   }
 


### PR DESCRIPTION
## Summary
- update title frame to be 50% wider and narrow the label column
- redraw canvas when assembly name changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685aec1dee1483269ce8e19e88b1b276