### PR TITLE
Add Print PDF button

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,6 +257,24 @@ if (bhaCanvas) {
   }
   redraw();
 
+  document.getElementById('printPdfBtn').onclick = () => {
+    const now = new Date();
+    const stamp = now.toISOString().replace(/[:T]/g, '-').split('.')[0];
+    const fileName = (assyObj.name || 'assembly') + '_' + stamp;
+    const imgData = bhaCanvas.toDataURL('image/png');
+    const win = window.open('', '_blank');
+    if (!win) return;
+    win.document.write('<html><head><title>' + fileName + '</title>');
+    win.document.write('<style>@page{margin:0;}body{margin:0;}img{width:100%;height:auto;}</style>');
+    win.document.write('</head><body>');
+    win.document.write('<img src="' + imgData + '">');
+    win.document.write('</body></html>');
+    win.document.close();
+    win.focus();
+    win.print();
+    win.onafterprint = () => win.close();
+  };
+
   document.getElementById('backAssyBtn').onclick = () => {
     assyObj.items = placed;
     saveCurrentBha();

--- a/builder.html
+++ b/builder.html
@@ -18,6 +18,7 @@
     </aside>
     <main id="dropZone" class="dropzone">
       <canvas id="bhaCanvas" width="794" height="1123"></canvas>
+      <button id="printPdfBtn" class="success print-btn">Print PDF</button>
       <button id="backAssyBtn" class="secondary back-btn">Back to Assemblies</button>
     </main>
   </section>

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ button{padding:.7rem 1.4rem;border:0;border-radius:12px;font-size:1rem;cursor:po
 button.primary{background:#007aff;color:#fff;}
 button.secondary{background:#e0e0e5;color:#1d1d1f;margin-left:1rem;}
 button.danger{background:#ff3b30;color:#fff;margin-left:1rem;}
+button.success{background:#28a745;color:#fff;margin-left:1rem;}
 button:hover{filter:brightness(.95);}
 
 /*  ─── Layout Containers ───────────────────────────────── */
@@ -20,6 +21,7 @@ button:hover{filter:brightness(.95);}
 .list div{display:flex;justify-content:space-between;}
 .back-btn{margin-top:1rem;}
 .view.builder .back-btn{position:absolute;bottom:1rem;left:1rem;margin-top:0;}
+.view.builder .print-btn{position:absolute;bottom:4rem;left:1rem;}
 
 /*  ensure older browsers respect the hidden attribute  */
 [hidden]{display:none!important;}


### PR DESCRIPTION
## Summary
- add `Print PDF` button to builder
- include success/print CSS styles
- allow printing the current canvas with timestamped filename

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685aee133adc8326acd9a00b63ce4601