### PR TITLE
Add thread and color actions to context menu

### DIFF
--- a/fdrawingv1/App.js
+++ b/fdrawingv1/App.js
@@ -399,6 +399,30 @@ document.getElementById("deleteShapeMenu").addEventListener("click", () => {
   contextPart = null;
 });
 
+document.getElementById("toggleTopThread").addEventListener("click", () => {
+  if (contextPart) toggleThread(contextPart, "top");
+  menu.style.display = "none";
+  contextPart = null;
+});
+
+document.getElementById("toggleBottomThread").addEventListener("click", () => {
+  if (contextPart) toggleThread(contextPart, "bottom");
+  menu.style.display = "none";
+  contextPart = null;
+});
+
+document.getElementById("flipMenu").addEventListener("click", () => {
+  if (contextPart) toggleFlip(contextPart);
+  menu.style.display = "none";
+  contextPart = null;
+});
+
+document.getElementById("changeColorMenu").addEventListener("click", () => {
+  if (contextPart) changePartColor(contextPart);
+  menu.style.display = "none";
+  contextPart = null;
+});
+
 document.getElementById("toggle3dMenu").addEventListener("click", () => {
   if (contextPart) {
     togglePart3D(contextPart);
@@ -1467,6 +1491,43 @@ function toggleConnector3D(conn) {
   else enableConnector3D(conn);
 }
 
+function toggleThread(part, pos) {
+  const prop = pos === 'top' ? 'topConnector' : 'bottomConnector';
+  const label = pos === 'top' ? part.topLabel : part.bottomLabel;
+  if (part[prop] && part[prop] !== 'none') {
+    part[prop] = 'none';
+    removeConnector(part, pos);
+    label.textContent = '';
+    updateConnectorLabelClass(label, 'none');
+  } else {
+    part[prop] = 'PIN';
+    createConnector(part, pos, 'PIN');
+    label.textContent = labelFor('PIN');
+    updateConnectorLabelClass(label, 'PIN');
+  }
+}
+
+function toggleFlip(part) {
+  part.flipped = !part.flipped;
+  if (part.flipped) {
+    const cx = part.x + part.width / 2;
+    const cy = part.y + part.height / 2;
+    part.g.setAttribute('transform', `rotate(180 ${cx} ${cy})`);
+  } else {
+    part.g.removeAttribute('transform');
+  }
+  if (part.connectors) {
+    updateConnectors(part);
+  }
+}
+
+function changePartColor(part) {
+  const c = prompt('Enter colour (e.g., #ff0000 or red):', part.color);
+  if (!c) return;
+  part.color = c;
+  applyPartGradient(part);
+}
+
 function stripShape(s) {
   const base = { type: s.type, width: s.width };
   if (s.parentPart) {
@@ -2016,6 +2077,23 @@ function showContextMenu(e, part = null, shape = null, connector = null) {
     shape && shape.parentPart ? 'block' : 'none';
   document.getElementById('deleteShapeMenu').style.display = shape ? 'block' : 'none';
   document.getElementById('toggle3dMenu').style.display = part || connector ? 'block' : 'none';
+  if (part) {
+    const topEnabled = part.topConnector && part.topConnector !== 'none';
+    const bottomEnabled = part.bottomConnector && part.bottomConnector !== 'none';
+    const tt = document.getElementById('toggleTopThread');
+    const tb = document.getElementById('toggleBottomThread');
+    tt.style.display = 'block';
+    tb.style.display = 'block';
+    tt.textContent = topEnabled ? 'Disable uphole thread' : 'Enable uphole thread';
+    tb.textContent = bottomEnabled ? 'Disable downhole thread' : 'Enable downhole thread';
+    document.getElementById('flipMenu').style.display = 'block';
+    document.getElementById('changeColorMenu').style.display = 'block';
+  } else {
+    document.getElementById('toggleTopThread').style.display = 'none';
+    document.getElementById('toggleBottomThread').style.display = 'none';
+    document.getElementById('flipMenu').style.display = 'none';
+    document.getElementById('changeColorMenu').style.display = 'none';
+  }
   const rect = canvasArea.getBoundingClientRect();
   menu.style.left = `${e.clientX - rect.left + canvasArea.scrollLeft}px`;
   menu.style.top = `${e.clientY - rect.top + canvasArea.scrollTop}px`;

--- a/fdrawingv1/index.html
+++ b/fdrawingv1/index.html
@@ -45,7 +45,11 @@
       <li id="attachShapeMenu" class="context-menu-item">Attach to body</li>
       <li id="detachShapeMenu" class="context-menu-item">Detach from body</li>
       <li id="deleteShapeMenu" class="context-menu-item">Delete shape</li>
+      <li id="toggleTopThread" class="context-menu-item">Enable uphole thread</li>
+      <li id="toggleBottomThread" class="context-menu-item">Enable downhole thread</li>
       <li id="toggle3dMenu" class="context-menu-item">Toggle 3D effect</li>
+      <li id="flipMenu" class="context-menu-item">Turn upside down</li>
+      <li id="changeColorMenu" class="context-menu-item">Change colour</li>
       <li id="setSizeMenu" class="context-menu-item">Set size</li>
       <li id="removeBody" class="context-menu-item">Delete body</li>
       <li id="undoAction" class="context-menu-item">Undo</li>


### PR DESCRIPTION
## Summary
- extend context menu in FDrawer with more options
- implement handlers for toggling uphole/downhole threads, flipping parts, changing colours
- default threads keep 3D effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b16957ed48326a6e4cd963f4c729a