### PR TITLE
Remove context menu and add thread 3D shading

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -18,12 +18,6 @@
     </aside>
     <main id="dropZone" class="dropzone">
       <canvas id="bhaCanvas" width="794" height="1123"></canvas>
-      <ul id="contextMenu" class="context-menu">
-        <li id="changeColorMenu" class="context-menu-item">Change colour</li>
-        <li id="toggleTopThread" class="context-menu-item">Enable uphole thread</li>
-        <li id="toggleBottomThread" class="context-menu-item">Enable downhole thread</li>
-        <li id="flipMenu" class="context-menu-item">Turn upside down</li>
-      </ul>
       <button id="scaleUpBtn" class="secondary scale-up-btn">Scale Up</button>
       <button id="scaleDownBtn" class="secondary scale-down-btn">Scale Down</button>
       <button id="printPdfBtn" class="success print-btn">Print PDF</button>

--- a/style.css
+++ b/style.css
@@ -49,7 +49,3 @@ button:hover{filter:brightness(.95);}
 /*  ─── Canvas ─────────────────────────────────────────── */
 #bhaCanvas{background:#fff;border:1px solid #dcdce0;margin-bottom:1rem;height:100%;aspect-ratio:210/297;width:auto;max-height:calc(100vh - 6rem);}
 
-/*  ─── Context Menu ───────────────────────────────────── */
-.context-menu{position:absolute;display:none;background:#fff;border:1px solid #ccc;list-style:none;padding:0;margin:0;z-index:1000;}
-.context-menu-item{padding:4px 8px;cursor:pointer;white-space:nowrap;}
-.context-menu-item:hover{background:#eee;}


### PR DESCRIPTION
## Summary
- remove builder context menu markup and styles
- eliminate context menu logic from builder script
- shade connector threads using same cylinder gradient as components

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c622548388326b4d23604f4844d7e