### PR TITLE
Enable adding custom components from FDrawer

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,6 +298,23 @@ if (bhaCanvas) {
     });
   });
 
+  const newComponentBtn = document.getElementById('newComponentBtn');
+  let drawerWin = null;
+  if (newComponentBtn) {
+    newComponentBtn.onclick = () => {
+      drawerWin = window.open('fdrawingv1/index.html', 'fdrawer');
+    };
+    window.addEventListener('message', e => {
+      if (!drawerWin || e.source !== drawerWin) return;
+      const msg = e.data || {};
+      if (msg.type === 'newComponent' && msg.component) {
+        drawerWin.close();
+        drawerWin = null;
+        addPaletteItem(normalizeComponent(msg.component), document.getElementById('privateList'));
+      }
+    });
+  }
+
   function addPaletteItem(comp, container) {
     const div = document.createElement('div');
     div.className = 'tool-item';

--- a/builder.html
+++ b/builder.html
@@ -10,6 +10,7 @@
   <section class="view builder">
     <aside id="palette" class="sidebar">
       <input id="assyTitle" class="assy-input" type="text" />
+      <button id="newComponentBtn" class="primary new-comp-btn">New component</button>
       <h2>Public Components</h2>
       <div id="publicList"></div>
       <h2>Private Components</h2>

--- a/fdrawingv1/App.js
+++ b/fdrawingv1/App.js
@@ -513,6 +513,9 @@ document.getElementById("exportBtn").addEventListener("click", () => {
     .replace(/[^a-z0-9_-]/gi, "_");
   a.download = `${safeName}.json`;
   a.click();
+  if (window.opener) {
+    window.opener.postMessage({ type: 'newComponent', component: data }, '*');
+  }
 });
 
 document.getElementById("importBtn").addEventListener("click", () =>

--- a/style.css
+++ b/style.css
@@ -38,6 +38,7 @@ button:hover{filter:brightness(.95);}
 .dropzone{flex:1;height:100%;padding:1rem;background:#e9f5ff;display:flex;flex-direction:column;align-items:center;overflow:auto;position:relative;}
 
 .assy-input{width:100%;margin-bottom:1rem;padding:.4rem;font-size:1.1rem;}
+.new-comp-btn{width:100%;margin-bottom:1rem;}
 .bha-component{border:2px solid #007aff;border-radius:8px;padding:.6rem;margin-bottom:.6rem;background:#fff;display:flex;justify-content:space-between;align-items:center;}
 .dim{color:#6e6e73;font-size:.9rem;}
 


### PR DESCRIPTION
## Summary
- add **New component** button to builder sidebar
- style button and handle communication with FDrawer
- when exporting from FDrawer send JSON back to the opener

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c66cb625c8326b2421e0ba0dceee3