### PR TITLE
Fix editing flow for components

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,9 +393,15 @@ if (bhaCanvas) {
     contextMenu.style.display = 'none';
     editTarget = contextTarget;
     drawerWin = window.open('fdrawingv1/index.html', 'fdrawer');
-    drawerWin.onload = () => {
+    const sendEditMsg = () => {
+      if (!drawerWin) return;
       drawerWin.postMessage({ type: 'editComponent', component: editTarget.comp }, '*');
     };
+    if (drawerWin.document && drawerWin.document.readyState === 'complete') {
+      sendEditMsg();
+    } else {
+      drawerWin.onload = sendEditMsg;
+    }
   });
 
   function getHandlePos(it) {

--- a/fdrawingv1/App.js
+++ b/fdrawingv1/App.js
@@ -28,7 +28,7 @@ const menu = document.getElementById("contextMenu");
 const canvasArea = document.getElementById("canvas_area");
 const partNameInput = document.getElementById("partName");
 const finishedBtn = document.getElementById("finishedBtn");
-if (window.opener && finishedBtn) finishedBtn.style.display = "block";
+if (finishedBtn) finishedBtn.style.display = "block";
 window.addEventListener('message', (e) => {
   if (window.opener && e.source === window.opener) {
     const msg = e.data || {};
@@ -536,6 +536,15 @@ document.getElementById("exportBtn").addEventListener("click", () => {
 if (finishedBtn) {
   finishedBtn.addEventListener('click', () => {
     const data = buildComponentData();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    const safeName = (partNameInput.value.trim() || 'diagram')
+      .replace(/[^a-z0-9_-]/gi, '_');
+    a.download = `${safeName}.json`;
+    a.click();
     if (window.opener) {
       window.opener.postMessage({ type: 'newComponent', component: data }, '*');
     }


### PR DESCRIPTION
## Summary
- show the drawing page `Finished` button by default and export on click
- ensure `modify` sends component data even when the drawer window is reused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ebb96808326ad4ee6eb72fb287a