### PR TITLE
Add component preview on hover

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,6 +271,30 @@ if (bhaCanvas) {
   let resizeStartDist = 0;
   let resizeStartScale = 1;
 
+  const previewCanvas = document.getElementById('previewCanvas');
+  const previewCtx = previewCanvas ? previewCanvas.getContext('2d') : null;
+
+  function showPreview(comp) {
+    if (!previewCanvas || !previewCtx) return;
+    previewCanvas.hidden = false;
+    previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+    const b = getComponentBounds(comp);
+    const scale = Math.min(
+      (previewCanvas.width - 20) / b.width,
+      (previewCanvas.height - 20) / b.height
+    );
+    previewCtx.save();
+    previewCtx.translate(previewCanvas.width / 2, previewCanvas.height / 2);
+    previewCtx.scale(scale, scale);
+    previewCtx.translate(-b.minX - b.width / 2, -b.minY - b.height / 2);
+    drawComponent(previewCtx, comp, 0, 0, false, 1);
+    previewCtx.restore();
+  }
+
+  function hidePreview() {
+    if (previewCanvas) previewCanvas.hidden = true;
+  }
+
   const nameInput = document.getElementById('assyTitle');
   const assyObj = currentBha.assemblies[currentAssemblyIdx] || { name: 'Assembly ' + (currentAssemblyIdx + 1), items: [] };
   nameInput.value = assyObj.name;
@@ -352,6 +376,8 @@ if (bhaCanvas) {
     div.addEventListener('dragstart', ev => {
       ev.dataTransfer.setData('application/json', div.dataset.comp);
     });
+    div.addEventListener('mouseenter', () => showPreview(comp));
+    div.addEventListener('mouseleave', hidePreview);
     if (isPrivate) {
       div.style.display = 'flex';
       div.style.alignItems = 'center';

--- a/builder.html
+++ b/builder.html
@@ -19,6 +19,7 @@
     </aside>
     <main id="dropZone" class="dropzone">
       <canvas id="bhaCanvas" width="794" height="1123"></canvas>
+      <canvas id="previewCanvas" width="200" height="200" class="preview-canvas" hidden></canvas>
       <button id="scaleUpBtn" class="secondary scale-up-btn">Scale Up</button>
       <button id="scaleDownBtn" class="secondary scale-down-btn">Scale Down</button>
       <button id="printPdfBtn" class="success print-btn">Print PDF</button>

--- a/style.css
+++ b/style.css
@@ -58,3 +58,6 @@ button:hover{filter:brightness(.95);}
 /*  ─── Canvas ─────────────────────────────────────────── */
 #bhaCanvas{background:#fff;border:1px solid #dcdce0;margin-bottom:1rem;height:100%;aspect-ratio:210/297;width:auto;max-height:calc(100vh - 6rem);}
 
+/*  ─── Component Preview ─────────────────────────────── */
+.preview-canvas{position:absolute;top:1rem;right:1rem;width:200px;height:200px;border:1px solid #dcdce0;background:#fff;pointer-events:none;}
+


### PR DESCRIPTION
## Summary
- show component preview when hovering over palette items
- add preview canvas and styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866fec3f7d08326a2965d6805bc8224