### PR TITLE
Fix builder snapping alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -660,24 +660,38 @@ if (bhaCanvas) {
       placed = placed.filter(p => p !== dragObj);
     }
 
-    // snapping logic
+    // snapping logic - allow attaching above or below nearby item
     const box = getItemBox(dragObj);
     let best = null;
     let bestDist = 20;
+    let attachAbove = false; // true if dragObj should become parent
     placed.forEach(o => {
       if (o === dragObj) return;
       const ob = getItemBox(o);
-      const dist = Math.abs(box.top - ob.bottom);
-      const centerDiff = Math.abs((box.left + box.right)/2 - (ob.left + ob.right)/2);
-      if (dist < bestDist && centerDiff < ob.width / 2) {
-        best = o; bestDist = dist;
+      const centerDiff = Math.abs((box.left + box.right) / 2 - (ob.left + ob.right) / 2);
+      if (centerDiff > Math.max(ob.width, box.width) / 2) return;
+
+      const distBelow = Math.abs(box.top - ob.bottom);
+      if (distBelow < bestDist) {
+        best = o; bestDist = distBelow; attachAbove = false;
+      }
+
+      const distAbove = Math.abs(box.bottom - ob.top);
+      if (distAbove < bestDist) {
+        best = o; bestDist = distAbove; attachAbove = true;
       }
     });
+
     if (best) {
       const pb = getItemBox(best);
-      dragObj.x += ( (pb.left + pb.right)/2 - (box.left + box.right)/2 );
-      dragObj.y += pb.bottom - box.top;
-      attachBelow(dragObj, best);
+      dragObj.x += ( (pb.left + pb.right) / 2 - (box.left + box.right) / 2 );
+      if (attachAbove) {
+        dragObj.y += pb.top - box.bottom;
+        attachBelow(best, dragObj);
+      } else {
+        dragObj.y += pb.bottom - box.top;
+        attachBelow(dragObj, best);
+      }
     } else {
       detach(dragObj);
     }


### PR DESCRIPTION
## Summary
- improve drag-and-drop snapping logic in `app.js`
  - allow snapping a component above or below another
  - keep snapped groups attached for right-click move

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68679b91d9648326ae45db0da143d652