### PR TITLE
Fix drag hit boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ On the builder page use the **Scale Up** and **Scale Down** buttons to adjust
 the size of every component on the canvas. Each click changes the component
 scale by 10%. Newly dropped components now use the current scale so they match
 the rest of the assembly.
+
+## Dragging
+
+Click anywhere within a component's body to drag it around the canvas. Each
+part's bounding box is now treated as a draggable area, so hollow regions are
+also easily clickable.

--- a/app.js
+++ b/app.js
@@ -537,6 +537,18 @@ if (bhaCanvas) {
     const bottom = it.y + b.maxY * scale;
     if (x >= left && x <= right && y >= top && y <= bottom) return true;
 
+    // Check bounding box of each part so hollow sections are still clickable
+    for (const p of it.comp.parts) {
+      const px = it.flipped ? b.width - p.x - p.width : p.x;
+      const py = it.flipped ? b.height - p.y - p.height : p.y;
+      const partLeft = it.x + px * scale;
+      const partRight = partLeft + p.width * scale;
+      const partTop = it.y + py * scale;
+      const partBottom = partTop + p.height * scale;
+      if (x >= partLeft && x <= partRight && y >= partTop && y <= partBottom)
+        return true;
+    }
+
     // Fall back to polygon hit test if needed
     for (const p of it.comp.parts) {
       const pts = partPolygonPoints(p, 0, 0).map(pt => {


### PR DESCRIPTION
## Summary
- improve hit testing for components so clicking anywhere on the body works
- note easier dragging in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68690d14d3508326baf2a95a1e4c6c15