### PR TITLE
Add diameter customization

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -30,6 +30,7 @@
         <li id="modifyItem" class="context-menu-item">Modify</li>
         <li id="removeLengthItem" class="context-menu-item">Remove length</li>
         <li id="removeDiameterItem" class="context-menu-item">Remove diameter</li>
+        <li id="toggleDiameterTypeItem" class="context-menu-item">Toggle diameter style</li>
       </ul>
     </main>
   </section>


### PR DESCRIPTION
## Summary
- add menu option to toggle diameter display style
- support double-ended or left-arrow diameter lines
- allow editing component diameter via double-click
- show values as fractions of 1/12" for clarity

## Testing
- `node --check app.js`
- `node --check fdrawingv1/App.js`

------
https://chatgpt.com/codex/tasks/task_e_68698c350b148326a8546228f18233e2