### PR TITLE
Add editable text boxes on builder page

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -22,6 +22,7 @@
       <canvas id="previewCanvas" width="200" height="200" class="preview-canvas" hidden></canvas>
       <button id="addLengthBtn" class="length-btn add-length-btn">Add lengths</button>
       <button id="addDiameterBtn" class="length-btn add-diameter-btn">Add diameter</button>
+      <button id="addTextBtn" class="length-btn add-text-btn">Add text</button>
       <button id="scaleUpBtn" class="secondary scale-up-btn">Scale Up</button>
       <button id="scaleDownBtn" class="secondary scale-down-btn">Scale Down</button>
       <button id="printPdfBtn" class="success print-btn">Print PDF</button>
@@ -31,6 +32,7 @@
         <li id="removeLengthItem" class="context-menu-item">Remove length</li>
         <li id="removeDiameterItem" class="context-menu-item">Remove diameter</li>
         <li id="toggleDiameterTypeItem" class="context-menu-item">Toggle diameter style</li>
+        <li id="deleteTextItem" class="context-menu-item">Delete text</li>
       </ul>
     </main>
   </section>

--- a/style.css
+++ b/style.css
@@ -28,6 +28,7 @@ button:hover{filter:brightness(.95);}
 .view.builder .scale-up-btn{position:absolute;bottom:10rem;left:1rem;}
 .view.builder .add-length-btn{position:absolute;bottom:13rem;left:1rem;}
 .view.builder .add-diameter-btn{position:absolute;bottom:16rem;left:1rem;}
+.view.builder .add-text-btn{position:absolute;bottom:19rem;left:1rem;}
 
 /* ─── Context Menu ─────────────────────────────────────── */
 .context-menu{position:absolute;display:none;background:#fff;border:1px solid #ccc;list-style:none;padding:0;margin:0;z-index:1000;}


### PR DESCRIPTION
## Summary
- add **Add text** button and delete menu item to builder page
- position new button in CSS
- implement text box creation, dragging, editing and deletion in `app.js`
- persist text boxes with assemblies and include them in PDF export

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_686a8b6c1f8083268e4d644a7ce18212