### PR TITLE
Update builder layout and field table

### DIFF
--- a/app.js
+++ b/app.js
@@ -364,15 +364,15 @@ if (bhaCanvas) {
   });
 
   const FIELD_DEFS = [
-    { id: 'shankOD', label: 'Shank OD' },
-    { id: 'totalLength', label: 'Total length' },
+    { id: 'totalLength', label: 'Total L' },
     { id: 'maxOD', label: 'Max OD' },
-    { id: 'fishNeckLength', label: 'Fish neck length' },
-    { id: 'fishNeckOD', label: 'Fish neck OD' },
     { id: 'minID', label: 'Minimum ID' },
-    { id: 'date', label: 'Date', getDefault: () => new Date().toISOString().split('T')[0] },
+    { id: 'fishNeckLength', label: 'Fish neck L' },
+    { id: 'fishNeckOD', label: 'Fish neck OD' },
+    { id: 'weight', label: 'Weight' },
     { id: 'basket', label: 'Basket' },
-    { id: 'comments', label: 'Comments', double: true }
+    { id: 'date', label: 'Date', getDefault: () => new Date().toISOString().split('T')[0] },
+    { id: 'comments', label: 'Comment', double: true }
   ];
   const fields = assyObj.fields || {};
   FIELD_DEFS.forEach(def => {
@@ -1686,9 +1686,9 @@ if (bhaCanvas) {
     fieldRects.length = 0;
     const active = FIELD_DEFS.filter(d => fields[d.id] && fields[d.id].enabled);
     if (!active.length) return;
-    const tbW = 270;
+    const tbW = 320;
     const smallRow = 20;
-    const titleCol = 50;
+    const titleCol = 100;
     const rowCount = active.reduce((a, d) => a + (d.double ? 2 : 1), 0);
     const tbH = smallRow * rowCount;
     const x = bhaCanvas.width - margin - tbW;
@@ -1891,9 +1891,9 @@ if (bhaCanvas) {
 
     const active = FIELD_DEFS.filter(d => fields[d.id] && fields[d.id].enabled);
     if (active.length) {
-      const tbW = 270 * scale;
+      const tbW = 320 * scale;
       const smallRow = 20 * scale;
-      const titleCol = 50 * scale;
+      const titleCol = 100 * scale;
       const rowCount = active.reduce((a, d) => a + (d.double ? 2 : 1), 0);
       const tbH = smallRow * rowCount;
       const x = width - margin - tbW;

--- a/builder.html
+++ b/builder.html
@@ -16,21 +16,20 @@
       <h2>Private Components</h2>
       <input type="file" id="privateInput" accept="application/json" multiple />
       <div id="privateList"></div>
-      <h2>Fields</h2>
-      <div id="fieldList" class="field-list">
-        <label><input type="checkbox" data-field="shankOD"> Shank OD</label><br>
-        <label><input type="checkbox" data-field="totalLength"> Total length</label><br>
-        <label><input type="checkbox" data-field="maxOD"> Max OD</label><br>
-        <label><input type="checkbox" data-field="fishNeckLength"> Fish neck length</label><br>
-        <label><input type="checkbox" data-field="fishNeckOD"> Fish neck OD</label><br>
-        <label><input type="checkbox" data-field="minID"> Minimum ID</label><br>
-        <label><input type="checkbox" data-field="date"> Date</label><br>
-        <label><input type="checkbox" data-field="basket"> Basket</label><br>
-        <label><input type="checkbox" data-field="comments"> Comments</label>
-      </div>
     </aside>
     <main id="dropZone" class="dropzone">
       <canvas id="bhaCanvas" width="794" height="1123"></canvas>
+      <div id="fieldList" class="field-list">
+        <label><input type="checkbox" data-field="totalLength"> Total L</label><br>
+        <label><input type="checkbox" data-field="maxOD"> Max OD</label><br>
+        <label><input type="checkbox" data-field="minID"> Minimum ID</label><br>
+        <label><input type="checkbox" data-field="fishNeckLength"> Fish neck L</label><br>
+        <label><input type="checkbox" data-field="fishNeckOD"> Fish neck OD</label><br>
+        <label><input type="checkbox" data-field="weight"> Weight</label><br>
+        <label><input type="checkbox" data-field="basket"> Basket</label><br>
+        <label><input type="checkbox" data-field="date"> Date</label><br>
+        <label><input type="checkbox" data-field="comments"> Comment</label>
+      </div>
       <canvas id="previewCanvas" width="200" height="200" class="preview-canvas" hidden></canvas>
       <button id="addLengthBtn" class="length-btn add-length-btn">Add lengths</button>
       <button id="addDiameterBtn" class="length-btn add-diameter-btn">Add diameter</button>

--- a/style.css
+++ b/style.css
@@ -48,6 +48,7 @@ button:hover{filter:brightness(.95);}
 
 /*  ─── Drop Zone (Assembly Stack) ──────────────────────── */
 .dropzone{flex:1;height:100%;padding:1rem;background:#e9f5ff;display:flex;flex-direction:column;align-items:center;overflow:auto;position:relative;}
+.field-list{position:absolute;right:1rem;bottom:1rem;background:#fff;border:1px solid #dcdce0;padding:.5rem;}
 .field-list label{display:block;margin-bottom:.3rem;}
 
 .assy-input{width:100%;margin-bottom:1rem;padding:.4rem;font-size:1.1rem;}


### PR DESCRIPTION
## Summary
- move field checkboxes next to the canvas
- reorder field definitions and add Weight option
- enlarge the first column when rendering the field table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ad498642c83268fbeb7e69ba58041