### PR TITLE
Add assembly previews and ordering controls

### DIFF
--- a/assembly.html
+++ b/assembly.html
@@ -7,11 +7,17 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="assembly">
-  <section class="view centered">
+  <section class="view centered" style="position:relative;">
     <h1 id="bhaTitle">BHA</h1>
     <div id="assemblyList" class="list"></div>
     <button id="addAssyBtn" class="primary">New Assembly</button>
+    <button id="printAllBtn" class="success">Print all</button>
     <button id="backMainBtn" class="secondary back-btn">Back</button>
+    <canvas id="assemblyPreview" width="210" height="297" class="assy-preview" hidden></canvas>
+    <ul id="assyContextMenu" class="context-menu">
+      <li data-action="up" class="context-menu-item">Move up</li>
+      <li data-action="down" class="context-menu-item">Move down</li>
+    </ul>
   </section>
   <script src="app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,8 @@ button:hover{filter:brightness(.95);}
 .builder{display:flex;}
 .list{width:260px;text-align:left;margin-bottom:1rem;}
 .list button{margin:0.3rem 0;}
-.list div{display:flex;justify-content:space-between;}
+.list div{display:flex;align-items:center;gap:.3rem;}
+.list .edit-btn{flex:1;white-space:normal;}
 .back-btn{margin-top:1rem;}
 .centered>button{margin:0.5rem 0;}
 .view.builder .back-btn{position:absolute;bottom:1rem;left:1rem;margin-top:0;}
@@ -34,6 +35,8 @@ button:hover{filter:brightness(.95);}
 .context-menu{position:absolute;display:none;background:#fff;border:1px solid #ccc;list-style:none;padding:0;margin:0;z-index:1000;}
 .context-menu-item{padding:4px 8px;cursor:pointer;white-space:nowrap;}
 .context-menu-item:hover{background:#eee;}
+
+.assy-num{margin-right:.5rem;}
 
 /*  ensure older browsers respect the hidden attribute  */
 [hidden]{display:none!important;}
@@ -66,4 +69,5 @@ button:hover{filter:brightness(.95);}
 
 /*  ─── Component Preview ─────────────────────────────── */
 .preview-canvas{position:absolute;top:1rem;right:1rem;width:200px;height:200px;border:1px solid #dcdce0;background:#fff;pointer-events:none;}
+.assy-preview{position:absolute;top:1rem;right:1rem;width:210px;height:297px;border:1px solid #dcdce0;background:#fff;}
 


### PR DESCRIPTION
## Summary
- enlarge assembly list layout and add numbering
- support moving assemblies via right-click context menu
- show preview of assembly when hovering over a row
- add ability to print all assemblies at once
- styling updates for list, preview pane and buttons

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_686ad7e36a5c8326a66819073335df1f