### PR TITLE
Improve PDF import quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ the rest of the assembly.
 Click anywhere within a component's body to drag it around the canvas. Each
 part's bounding box is now treated as a draggable area, so hollow regions are
 also easily clickable.
+
+## External drawings
+
+When uploading PDF drawings as assemblies the pages are now rendered at a
+higher resolution before being added to your BHA. This results in clearer
+images when exporting or printing your assemblies.

--- a/app.js
+++ b/app.js
@@ -4,6 +4,10 @@ let currentAssembly = [];
 let currentAssemblyIdx = 0;
 const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 
+// Scale used when rendering imported PDF pages to images. Higher values
+// produce better quality at the cost of memory usage.
+const PDF_IMPORT_SCALE = 4; // default was 2
+
 let CONNECTOR_TEMPLATE = null;
 
 function preprocessConnectorTemplate(data) {
@@ -370,7 +374,7 @@ if (assemblyList) {
           const pdf = await pdfjsLib.getDocument(url).promise;
           for (let p = 1; p <= pdf.numPages; p++) {
             const page = await pdf.getPage(p);
-            const viewport = page.getViewport({ scale: 2 });
+            const viewport = page.getViewport({ scale: PDF_IMPORT_SCALE });
             const c = document.createElement('canvas');
             c.width = viewport.width;
             c.height = viewport.height;


### PR DESCRIPTION
## Summary
- scale imported PDF pages with a new `PDF_IMPORT_SCALE` constant
- update README with info about higher quality external drawings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/FDiagram/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_686bcbb287fc832681f7df94392433f2