### PR TITLE
Change edit flow to start blank component

### DIFF
--- a/app.js
+++ b/app.js
@@ -739,22 +739,22 @@ if (bhaCanvas) {
     contextMenu.style.display = 'none';
     editTarget = contextTarget;
     drawerWin = window.open(FDRAWER_URL, 'fdrawer');
-    const sendEditMsg = () => {
+    const sendNewBodyMsg = () => {
       if (drawerWin && !drawerWin.closed) {
-        drawerWin.postMessage({ type: 'editComponent', component: editTarget.comp }, '*');
+        drawerWin.postMessage({ type: 'addBody' }, '*');
       }
     };
     if (drawerWin) {
       let attempts = 0;
       const interval = setInterval(() => {
         attempts++;
-        sendEditMsg();
+        sendNewBodyMsg();
         if (!drawerWin || drawerWin.closed || attempts >= 10) {
           clearInterval(interval);
         }
       }, 300);
       drawerWin.onload = () => {
-        sendEditMsg();
+        sendNewBodyMsg();
       };
     }
   });

--- a/fdrawingv1/App.js
+++ b/fdrawingv1/App.js
@@ -35,6 +35,9 @@ window.addEventListener('message', (e) => {
     if (msg.type === 'editComponent' && msg.component) {
       saveState();
       loadFromData(msg.component);
+    } else if (msg.type === 'addBody') {
+      // mimic the user clicking the "Create body" button
+      addBody();
     }
   }
 });


### PR DESCRIPTION
## Summary
- open the drawing tool with a blank component when modifying an item
- allow the drawing tool to listen for an `addBody` message and create a new body automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870318a5ed083269dcaf833521cb0dc